### PR TITLE
Only require the core of echarts to reduce the dependency size.

### DIFF
--- a/src/WordCloudSeries.js
+++ b/src/WordCloudSeries.js
@@ -1,5 +1,5 @@
 var completeDimensions = require('echarts/lib/data/helper/completeDimensions');
-var echarts = require('echarts');
+var echarts = require('echarts/lib/echarts');
 
 echarts.extendSeriesModel({
 

--- a/src/WordCloudView.js
+++ b/src/WordCloudView.js
@@ -1,4 +1,4 @@
-var echarts = require('echarts');
+var echarts = require('echarts/lib/echarts');
 
 function getShallow(model, path) {
     return model && model.getShallow(path);

--- a/src/wordCloud.js
+++ b/src/wordCloud.js
@@ -1,4 +1,4 @@
-var echarts = require('echarts');
+var echarts = require('echarts/lib/echarts');
 var layoutUtil = require('echarts/lib/util/layout');
 
 require('./WordCloudSeries');


### PR DESCRIPTION
Currently in  echarts-wordcloud we use `require('echarts')`, however only the core component is enough for echarts-wordcloud. Only require the core component instead of the whole echarts package would help reduce the bundle size from 600+ KB to 220 KB.

It's worth merging this significant optimization into our next release.