### PR TITLE
Bug fix: 当数据含有null值，词云图渲染不出，或者渲染数据不全

### DIFF
--- a/src/layout.js
+++ b/src/layout.js
@@ -573,8 +573,13 @@ if (!window.clearImmediate) {
       fctx.fillText(word, fillTextOffsetX * mu,
                     (fillTextOffsetY + fontSize * 0.5) * mu);
 
-      // Get the pixels of the text
-      var imageData = fctx.getImageData(0, 0, width, height).data;
+			// Get the pixels of the text
+			var imageData;
+			try {
+				imageData = fctx.getImageData(0, 0, width, height).data;
+			} catch (error) {
+				return false;
+			}
 
       if (exceedTime()) {
         return false;


### PR DESCRIPTION
when value is null, the fontSize of text will be NaN, causing DOMException at function getTextInfo

![image](https://user-images.githubusercontent.com/15646325/49149609-7bcb1580-f345-11e8-9ce2-cd0d8f162159.png)
