### PR TITLE
feat: support keepAspect of shape and maskImage

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@ Third-party Wordcloud extension based on [wordcloud2.js](https://github.com/timd
 
 ![](./example/word-cloud.png)
 
-
 ## Examples
 
 [Google Trends](https://ecomfe.github.io/echarts-wordcloud/example/wordCloud.html)
@@ -26,7 +25,7 @@ npm install echarts-wordcloud
 ```
 
 ```js
-import * as echarts from 'echarts'
+import * as echarts from 'echarts';
 import 'echarts-wordcloud';
 ```
 
@@ -51,6 +50,10 @@ chart.setOption({
         // alias of square), triangle-forward, triangle, (alias of triangle-upright, pentagon, and star.
 
         shape: 'circle',
+
+        // Keep aspect ratio of maskImage or 1:1 for shapes
+
+        keepAspect: false,
 
         // A silhouette image which the white area will be excluded from drawing texts.
         // The shape option will continue to apply as the shape of the cloud to grow.

--- a/example/optionKeywords.html
+++ b/example/optionKeywords.html
@@ -1,10 +1,10 @@
 <html>
     <head>
         <meta charset="utf-8">
-        <script src='http://localhost/echarts/dist/echarts.js'></script>
+        <script src='https://cdn.jsdelivr.net/npm/echarts@5/dist/echarts.min.js'></script>
 
         <!-- <script src="../../echarts/dist/echarts.js"></script> -->
-        <script src='https://cdn.jsdelivr.net/npm/echarts@5/dist/echarts.min.js'></script>
+        <script src='../dist/echarts-wordcloud.js'></script>
     </head>
     <body>
         <style>

--- a/example/optionKeywords.html
+++ b/example/optionKeywords.html
@@ -1,7 +1,7 @@
 <html>
     <head>
         <meta charset="utf-8">
-        <script src='https://cdn.jsdelivr.net/npm/echarts@5/dist/echarts.min.js'></script>
+        <script src='http://localhost/echarts/dist/echarts.js'></script>
 
         <!-- <script src="../../echarts/dist/echarts.js"></script> -->
         <script src='../dist/echarts-wordcloud.js'></script>
@@ -377,6 +377,8 @@
                     shape: 'pentagon',
                     maskImage: maskImage,
                     drawOutOfBound: false,
+                    // layoutAnimation: true,
+                    keepAspect: true,
                     textStyle: {
                         fontWeight: 'bold',
                         color: function () {

--- a/example/optionKeywords.html
+++ b/example/optionKeywords.html
@@ -4,7 +4,7 @@
         <script src='http://localhost/echarts/dist/echarts.js'></script>
 
         <!-- <script src="../../echarts/dist/echarts.js"></script> -->
-        <script src='../dist/echarts-wordcloud.js'></script>
+        <script src='https://cdn.jsdelivr.net/npm/echarts@5/dist/echarts.min.js'></script>
     </head>
     <body>
         <style>

--- a/src/WordCloudSeries.js
+++ b/src/WordCloudSeries.js
@@ -31,6 +31,7 @@ echarts.extendSeriesModel({
 
     // Shape can be 'circle', 'cardioid', 'diamond', 'triangle-forward', 'triangle', 'pentagon', 'star'
     shape: 'circle',
+    keepAspect: false,
 
     left: 'center',
 

--- a/src/layout.js
+++ b/src/layout.js
@@ -1139,7 +1139,7 @@ var WordCloud = function WordCloud(elements, options) {
       : [ngx / 2, ngy / 2];
 
     // Maxium radius to look for space
-    maxRadius = Math.floor(Math.max(ngx, ngy) / 2);
+    maxRadius = Math.floor(Math.sqrt(ngx * ngx + ngy * ngy));
 
     /* Clear the canvas only if the clearCanvas is set,
          if not, update the grid to the current canvas state */

--- a/src/layout.js
+++ b/src/layout.js
@@ -1148,7 +1148,7 @@ var WordCloud = function WordCloud(elements, options) {
       : [ngx / 2, ngy / 2];
 
     // Maxium radius to look for space
-    maxRadius = Math.floor(Math.sqrt(ngx * ngx + ngy * ngy));
+    maxRadius = Math.floor(Math.max(ngx, ngy) / 2);
 
     /* Clear the canvas only if the clearCanvas is set,
          if not, update the grid to the current canvas state */

--- a/src/wordCloud.js
+++ b/src/wordCloud.js
@@ -61,6 +61,12 @@ echarts.registerLayout(function (ecModel, api) {
         height: api.getHeight()
       }
     );
+
+    var keepAspect = seriesModel.get('keepAspect');
+    var maskImage = seriesModel.get('maskImage');
+    var ratio = maskImage ? maskImage.width / maskImage.height : 1;
+    keepAspect && adjustRectAspect(gridRect, ratio);
+
     var data = seriesModel.getData();
 
     var canvas = document.createElement('canvas');
@@ -68,7 +74,6 @@ echarts.registerLayout(function (ecModel, api) {
     canvas.height = gridRect.height;
 
     var ctx = canvas.getContext('2d');
-    var maskImage = seriesModel.get('maskImage');
     if (maskImage) {
       try {
         ctx.drawImage(maskImage, 0, 0, canvas.width, canvas.height);
@@ -192,3 +197,17 @@ echarts.registerPreprocessor(function (option) {
       });
   }
 });
+
+function adjustRectAspect(gridRect, aspect) {
+  // var outerWidth = gridRect.width + gridRect.x * 2;
+  // var outerHeight = gridRect.height + gridRect.y * 2;
+  var width = gridRect.width;
+  var height = gridRect.height;
+  if (width > height * aspect) {
+    gridRect.x += (width - height * aspect) / 2;
+    gridRect.width = height * aspect;
+  } else {
+    gridRect.y += (height - width / aspect) / 2;
+    gridRect.height = width / aspect;
+  }
+}


### PR DESCRIPTION
API changes: added `keepAspect` with default value `false` (to comply with old versions).

## Feature 1: support `keepAspect`

### Before:

![image](https://user-images.githubusercontent.com/779050/146511760-4d6876c2-73d1-44d6-b767-45511cf9aa9f.png)

### After:

![image](https://user-images.githubusercontent.com/779050/146511698-b5514118-702f-49aa-a5b0-4d5cfb796f6c.png)

## Feature 2: better perserves shape

### Before:

In some cases, the shape is often larger than it should be. For example, if we set `shape` to be `'star'`, the overall shape looks much better than it should be.

![image](https://user-images.githubusercontent.com/779050/146519725-7b9cd6f8-612b-4e67-9950-81e2ce0b5d62.png)

This is even more obvious when `keepAspect` is set to be true:

![image](https://user-images.githubusercontent.com/779050/146520295-736b5585-5f63-4f82-a86c-22024267405c.png)

### After:

Although not perfect, after fixing, the shape is more obviously perserved.

![image](https://user-images.githubusercontent.com/779050/146520765-4d416747-c4be-4b47-960b-bd1c93a64461.png)

![image](https://user-images.githubusercontent.com/779050/146520645-d3c8fd49-b07f-470c-aa0b-7197dc7c1537.png)
