### PR TITLE
create canvas only once

### DIFF
--- a/src/wordCloud.js
+++ b/src/wordCloud.js
@@ -53,6 +53,7 @@ function updateCanvasMask(maskCanvas) {
 }
 
 echarts.registerLayout(function (ecModel, api) {
+  var canvas = document.createElement('canvas');
   ecModel.eachSeriesByType('wordCloud', function (seriesModel) {
     var gridRect = echarts.helper.getLayoutRect(
       seriesModel.getBoxLayoutParams(),
@@ -69,7 +70,6 @@ echarts.registerLayout(function (ecModel, api) {
 
     var data = seriesModel.getData();
 
-    var canvas = document.createElement('canvas');
     canvas.width = gridRect.width;
     canvas.height = gridRect.height;
 


### PR DESCRIPTION
Currently, canvas will be created every render(every setOption). When last render has not been finished, the event listeners(like wordcloudstart) won't be removed when setOption invoked, which cause memory leak and will affect next render(if last render has too much data, next render will be very slow). Canvas should only be created once.